### PR TITLE
Fixing $in, $nin, $all when using string

### DIFF
--- a/lib/finder.js
+++ b/lib/finder.js
@@ -367,7 +367,7 @@ var ops = {
 					m = _.intersection(m,index.match(this._args[i]._get()));
 			}
 			return m;				
-		},		
+		},	
 		this.native = function (obj) {
 			if (this._args.length==1)
 				return "true";
@@ -376,7 +376,12 @@ var ops = {
 			s+= "if (!v) return false;\n";				
 			s+="var args=[";
 			for (var i=1; i<this._args.length; i++) {
-				s+="'"+this._args[i]._get()+"'";
+                                val=this._args[i]._get();
+				if(val instanceof RegExp){
+					s+=val;
+				} else {
+					s+="'"+val+"'";
+				}
 				if (i!=this._args.length-1)
 					s+=",";
 			}
@@ -401,7 +406,12 @@ var ops = {
 			s+= "if (!Array.isArray(vv[0])) vv=[vv];\n";
 			s+="var args=[";
 			for (var i=1; i<this._args.length; i++) {
-				s+="'"+this._args[i]._get()+"'";
+				val=this._args[i]._get();
+				if(val instanceof RegExp){
+					s+=val;
+				} else {
+					s+="'"+val+"'";
+				}
 				if (i!=this._args.length-1)
 					s+=",";
 			}


### PR DESCRIPTION
This patch correct a bug when requesting with string list conditions.

var Engine = require('tingodb')()
var db = new Engine.Db('./test', {});
var collection = db.collection("test");

collection.insert([{field:"A"},{field:"B"},{field:"C"}],function(){
    collection.find({field:{$in: ["A","C"]}}).count(function(err,cnt){
        console.log(cnt);
    });
});

before : undefined
after : 2
