### PR TITLE
Added a test for the $in clause.

### DIFF
--- a/test/misc-test.js
+++ b/test/misc-test.js
@@ -77,4 +77,14 @@ describe('Misc', function () {
 			}))
 		}))
 	})
+        it('GH-21 $in should work as the intersection between the property array and the parameter array', function(done) {
+                db.collection("GH21", {}, safe.sure(done,function (_coll) {
+			_coll.insert({item: "abc", qty: 10, tags: [ "school", "clothing" ], sale: false }, safe.sure(done, function () {
+				_coll.find({tags: { $in: ["appliances", "school"] }}).toArray(safe.sure(done, function (docs) {
+					assert(docs.length,1);
+					done()
+				}))
+			}))
+		}))
+        })
 });


### PR DESCRIPTION
The $in clause doesn't work as expected ( http://docs.mongodb.org/manual/reference/operator/query/in/ ) when working with arrays. 

When searching for an array of values into an array field of a collection, the intersection doesn't work.