### PR TITLE
test to reproduce issue with escaped dots in tingodb (mongodb works)

### DIFF
--- a/test/misc-test.js
+++ b/test/misc-test.js
@@ -107,4 +107,18 @@ describe('Misc', function () {
 			}))
 		}))
 	})
+	it('double escape for . can not be found in tingodb but in mongodb', function (done) {
+		db.collection("GHXX", {}, safe.sure(done,function (_coll) {
+			_coll.insert([{hello:'.'}, {hello:'something else'}], {w:1}, safe.sure(done, function(result) {
+				_coll.findOne({hello: new RegExp('^\.$')}, safe.sure(done, function(item) {
+					assert.equal('.', item.hello); //normally escaped works					
+					_coll.findOne({hello: new RegExp('^\\.$')}, safe.sure(done, function(item) {
+						assert.equal('.', item.hello); //doubly escaped does not work
+						done()
+					}))	
+				}))
+				
+			}))
+		}))
+	})
 });

--- a/test/misc-test.js
+++ b/test/misc-test.js
@@ -107,8 +107,8 @@ describe('Misc', function () {
 			}))
 		}))
 	})
-	it('double escape for . can not be found in tingodb but in mongodb', function (done) {
-		db.collection("GHXX", {}, safe.sure(done,function (_coll) {
+	it('GH-84 double escape for . can not be found in tingodb but in mongodb', function (done) {
+		db.collection("GH84", {}, safe.sure(done,function (_coll) {
 			_coll.insert([{hello:'.'}, {hello:'something else'}], {w:1}, safe.sure(done, function(result) {
 				_coll.findOne({hello: new RegExp('^\.$')}, safe.sure(done, function(item) {
 					assert.equal('.', item.hello); //normally escaped works					


### PR DESCRIPTION
I found a weird nuance when searching with regular expressions that escape dots with double backslashes.

In mongodb I can use ^\.$ and ^\\.$ to find a simple .
In tingodb the same does not work. I attached a test to reproduce the issue. Whether or not it makes sense to escape with a double \, not sure.. there seems to be a different behaviour in mongodb here though. The test only fails when I run it with tingodb.

p.s.: for me this makes using the current keystonejs hard with tingodb, since they chose to use \\. escapes for email addresses in the backend login.