### PR TITLE
support numeric/ObjectId properties

### DIFF
--- a/lib/finder.js
+++ b/lib/finder.js
@@ -701,7 +701,7 @@ var field = function (k) {
 		var s = "(";
 		var ps = "obj";
 		for (var i=0;i<path.length;i++) {
-			ps+="."+path[i];
+			ps+="['"+path[i]+"']";
 			if (i!=path.length-1)
 				s+=ps+ " && ";
 			else


### PR DESCRIPTION
this change references properties via the array key syntax
without it a "SyntaxError: Unexpected token ILLEGAL" occurs on documents such as

```{ property : { 
  123 : 'ok' 
} }```