### PR TITLE
Fix _id null problem

### DIFF
--- a/lib/tcoll.js
+++ b/lib/tcoll.js
@@ -780,7 +780,7 @@ tcoll.prototype.findAndModify = function (query, sort, doc, opts, cb) {
 					$doc = $doc || query;
 					$doc = self._tdb._cloneDeep($doc);
 					updater.update($doc,true);
-					if (_.isUndefined($doc._id) || isNull($doc._id))
+					if (_.isUndefined($doc._id) || _.isNull($doc._id))
 						$doc._id = new self._tdb.ObjectID();
 					self._put($doc, false, safe.sure(cb, function () {
 						cb(null,opts.new?c._projectFields($doc):{})

--- a/lib/tcoll.js
+++ b/lib/tcoll.js
@@ -395,7 +395,7 @@ tcoll.prototype.insert = function (docs, opts, cb ) {
 		docs = [docs];
 	this._tq.add(function (cb) {
 		safe.forEachSeries(docs, function (doc, cb) {
-			if (_.isUndefined(doc._id)) {
+			if (_.isUndefined(doc._id) || _.isNull(doc._id)) {
 				doc._id = new self._tdb.ObjectID();
 			}
 			self._put(doc, false, cb);
@@ -475,7 +475,7 @@ tcoll.prototype._putM = function (item_, remove, cb) {
 			err.errmsg = err.toString();
 			return cb(err)
 		}
-		if (_.isUndefined(item._id))
+		if (_.isUndefined(item._id) || _.isNull(item._id))
 			return cb(new Error("Invalid object key (_id)"));
 
 		var key = {_id:simplifyKey(item._id)};
@@ -526,7 +526,7 @@ tcoll.prototype._putFS = function (item, remove, cb) {
 			err.errmsg = err.toString();
 			return cb(err)
 		}
-		if (_.isUndefined(item._id))
+		if (_.isUndefined(item._id) || _.isNull(item._id))
 			return cb(new Error("Invalid object key (_id)"));
 		item = self._wrapTypes(item);
 		var sobj = new Buffer(remove?"":JSON.stringify(item));
@@ -725,7 +725,7 @@ tcoll.prototype.update = function (query, doc, opts, cb) {
 					$doc = $doc || query;
 					$doc = self._tdb._cloneDeep($doc);
 					updater.update($doc,true);
-					if (_.isUndefined($doc._id))
+					if (_.isUndefined($doc._id) || _.isNull($doc._id))
 						$doc._id = new self._tdb.ObjectID();
 					self._put($doc, false, safe.sure(cb, function () {
 						cb(null, 1,{updatedExisting:false,upserted:$doc._id,n:1})
@@ -780,7 +780,7 @@ tcoll.prototype.findAndModify = function (query, sort, doc, opts, cb) {
 					$doc = $doc || query;
 					$doc = self._tdb._cloneDeep($doc);
 					updater.update($doc,true);
-					if (_.isUndefined($doc._id))
+					if (_.isUndefined($doc._id) || isNull($doc._id))
 						$doc._id = new self._tdb.ObjectID();
 					self._put($doc, false, safe.sure(cb, function () {
 						cb(null,opts.new?c._projectFields($doc):{})
@@ -819,7 +819,7 @@ tcoll.prototype.save = function (doc, opts, cb) {
 	this._tq.add(function (cb) {
 		var res = doc;
 		(function(cb) {
-			if (_.isUndefined(doc._id)) {
+			if (_.isUndefined(doc._id) || _.isNull(doc._id)) {
 				doc._id = new self._tdb.ObjectID();
 				cb()
 			} else {


### PR DESCRIPTION
Putting a record with id = null would make whole table crash.

for example:
db.collection('table').update(condition, {_id: null, some: 'data'}, {w:1, upsert: true}, function(err) {});