### PR TITLE
Made findAndModify() callbacks use findAndModifyWriteOpResult

### DIFF
--- a/lib/tcoll.js
+++ b/lib/tcoll.js
@@ -784,13 +784,15 @@ tcoll.prototype.findAndModify = function (query, sort, doc, opts, cb) {
 					$doc = $doc || query;
 					$doc = self._tdb._cloneDeep($doc);
 					updater.update($doc,true);
-					if (_.isUndefined($doc._id))
+					if (_.isUndefined($doc._id)) {
 						$doc._id = new self._tdb.ObjectID();
+					}
 					self._put($doc, false, safe.sure(cb, function () {
-						cb(null,opts.new?c._projectFields($doc):{})
+						cb(null, opts.new ? { value: c._projectFields($doc), ok: 1 } : {});
 					}))
-				} else
+				} else {
 					cb();
+				}
 			} else {
 				self._get(res[0], false, safe.sure(cb, function (obj) {
 					var robj = (opts.new && !opts.remove) ? obj : self._tdb._cloneDeep(obj);
@@ -806,7 +808,7 @@ tcoll.prototype.findAndModify = function (query, sort, doc, opts, cb) {
 					udoc._id = obj._id;
 					// put will add it back to indexes
 					self._put(udoc, opts.remove?true:false, safe.sure(cb,function () {
-						cb(null,c._projectFields(robj))
+						cb(null, { value: c._projectFields(robj), ok: 1 });
 					}))
 				}))
 			}

--- a/test/contrib/find_tests.js
+++ b/test/contrib/find_tests.js
@@ -588,36 +588,36 @@ exports.shouldCorrectlyFindAndModifyDocument = function(configuration, test) {
     // Test return new document on change
     collection.insert({'a':1, 'b':2}, {w:1}, function(err, doc) {
       // Let's modify the document in place
-      collection.findAndModify({'a':1}, [['a', 1]], {'$set':{'b':3}}, {'new':true}, function(err, updated_doc) {
-        test.equal(1, updated_doc.a);
-        test.equal(3, updated_doc.b);
+      collection.findAndModify({'a':1}, [['a', 1]], {'$set':{'b':3}}, {'new':true}, function(err, update_res) {
+        test.equal(1, update_res.value.a);
+        test.equal(3, update_res.value.b);
 
         // Test return old document on change
         collection.insert({'a':2, 'b':2}, {w:1}, function(err, doc) {
           // Let's modify the document in place
-          collection.findAndModify({'a':2}, [['a', 1]], {'$set':{'b':3}}, {w:1}, function(err, result, object) {
-            test.equal(2, result.a);
-            test.equal(2, result.b);
+          collection.findAndModify({'a':2}, [['a', 1]], {'$set':{'b':3}}, {w:1}, function(err, update_res, object) {
+            test.equal(2, update_res.value.a);
+            test.equal(2, update_res.value.b);
 
             // Test remove object on change
             collection.insert({'a':3, 'b':2}, {w:1}, function(err, doc) {
               // Let's modify the document in place
-              collection.findAndModify({'a':3}, [], {'$set':{'b':3}}, {'new': true, remove: true}, function(err, updated_doc) {
-                test.equal(3, updated_doc.a);
-                test.equal(2, updated_doc.b);
+              collection.findAndModify({'a':3}, [], {'$set':{'b':3}}, {'new': true, remove: true}, function(err, update_res) {
+                test.equal(3, update_res.value.a);
+                test.equal(2, update_res.value.b);
 
                 // Let's upsert!
-                collection.findAndModify({'a':4}, [], {'$set':{'b':3}}, {'new': true, upsert: true}, function(err, updated_doc) {
-                  test.equal(4, updated_doc.a);
-                  test.equal(3, updated_doc.b);
+                collection.findAndModify({'a':4}, [], {'$set':{'b':3}}, {'new': true, upsert: true}, function(err, update_res) {
+                  test.equal(4, update_res.value.a);
+                  test.equal(3, update_res.value.b);
 
                   // Test selecting a subset of fields
                   collection.insert({a: 100, b: 101}, {w:1}, function (err, ids) {
-                    collection.findAndModify({'a': 100}, [], {'$set': {'b': 5}}, {'new': true, fields: {b: 1}}, function (err, updated_doc) {
-                      test.equal(2, Object.keys(updated_doc).length);
-                      test.equal(ids[0]['_id'].toHexString(), updated_doc._id.toHexString());
-                      test.equal(5, updated_doc.b);
-                      test.equal("undefined", typeof updated_doc.a);
+                    collection.findAndModify({'a': 100}, [], {'$set': {'b': 5}}, {'new': true, fields: {b: 1}}, function (err, update_res) {
+                      test.equal(2, Object.keys(update_res.value).length);
+                      test.equal(ids[0]['_id'].toHexString(), update_res.value._id.toHexString());
+                      test.equal(5, update_res.value.b);
+                      test.equal("undefined", typeof update_res.value.a);
                       test.done();
                     });
                   });

--- a/test/misc-test.js
+++ b/test/misc-test.js
@@ -27,8 +27,8 @@ describe('Misc', function () {
 	it('GH-19 Unset must clean key from object', function (done) {
 		db.collection("GH19", {}, safe.sure(done,function (_coll) {
 			_coll.insert({name:'Tony',age:'37'}, safe.sure(done, function () {
-				_coll.findAndModify({},{age:1},{$set: {name: 'Tony'}, $unset: { age: true }},{new:true},safe.sure(done, function (doc) {
-					assert(!_.includes(_.keys(doc),'age'));
+				_coll.findAndModify({},{age:1},{$set: {name: 'Tony'}, $unset: { age: true }},{new:true},safe.sure(done, function (result) {
+					assert(!_.includes(_.keys(result.value),'age'));
 					_coll.findOne({},{age:1},safe.sure(done, function (obj) {
 						assert(!_.includes(_.keys(obj),'age'));
 						done();
@@ -91,8 +91,8 @@ describe('Misc', function () {
 	it('GH-26-2 sort order can also be optional and undefined for findAndRemove', function (done) {
 		db.collection("GH26-2", {}, safe.sure(done,function (_coll) {
 			_coll.insert({name:'Tony',age:'37'}, safe.sure(done, function () {
-				_coll.findAndModify({},{age:1},{$set: {name: 'Tony'}, $unset: { age: true }},undefined,safe.sure(done, function (doc) {
-					assert(doc.age);
+				_coll.findAndModify({},{age:1},{$set: {name: 'Tony'}, $unset: { age: true }},undefined,safe.sure(done, function (result) {
+					assert(result.value.age);
 					done();
 				}))
 			}))
@@ -102,8 +102,8 @@ describe('Misc', function () {
 	it('GH-26-3 doc can be undefined if remote is true for findAndModify', function (done) {
 		db.collection("GH26-3", {}, safe.sure(done,function (_coll) {
 			_coll.insert({name:'Tony',age:'37'}, safe.sure(done, function () {
-				_coll.findAndModify({},{age:1},undefined,{remove:true},safe.sure(done, function (doc) {
-					assert(doc.age);
+				_coll.findAndModify({},{age:1},undefined,{remove:true},safe.sure(done, function (result) {
+					assert(result.value.age);
 					done();
 				}))
 			}))

--- a/test/update-test.js
+++ b/test/update-test.js
@@ -100,8 +100,8 @@ describe('Incremental update', function () {
 		})
 		it("#1 $setOnInsert on findAndUpdate",function (done) {
 			db.collection("setOnInsert", {}, safe.sure(done,function (_coll) {
-				_coll.findAndModify({_id:2},{},{$setOnInsert:{name:"John",sub:{gender:"male"}}},{upsert:true,new:true}, safe.sure(done, function (obj) {
-					assert.deepEqual(obj,{"_id":2,"name":"John","sub":{"gender":"male"}});
+				_coll.findAndModify({_id:2},{},{$setOnInsert:{name:"John",sub:{gender:"male"}}},{upsert:true,new:true}, safe.sure(done, function (result) {
+					assert.deepEqual(result.value,{"_id":2,"name":"John","sub":{"gender":"male"}});
 					done();
 				}))
 			}))


### PR DESCRIPTION
The mongodb-native-driver > 1.x does return an [findAndModifyWriteOpResult](http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#~findAndModifyWriteOpResult) in the callback.

This change should mimic the behaviour of mongo-native-driver for `findAndModify()`.
It makes Mongoose work correctly with the TingoDB in many cases.

I also adapted the tests, but I'm not too sure about these changes as the tests seem to not work under windows at all.