### PR TITLE
Compatibility with newest versions of Node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "8"
   - "6"
   - "4"
   - "0.12"

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,5 @@
 var safe = require('safe');
+
 module.exports = function (opts) {
 	opts = opts || {};
 	var db = require('./tdb.js');

--- a/lib/tcoll.js
+++ b/lib/tcoll.js
@@ -94,7 +94,7 @@ tcoll.prototype.initFS = function (tdb, name, options, create, cb) {
 			var b1 = new Buffer(45);
 			safe.whilst(function () { return self._fsize === null; }, function(cb) {
 				safe.run(function (cb) {
-					fs.read(fd, b1, 0, 45, pos, safe.trap_sure(cb, function (bytes, data) {
+					fs.read(fd, b1, 0, 45, pos, safe.sure(cb, function (bytes, data) {
 						if (bytes===0) {
 							self._fsize = pos;
 							return cb();
@@ -183,7 +183,7 @@ tcoll.prototype._compact = function (cb) {
 	fs.open(filename, 'w+', safe.sure(cb, function (fd) {
 		var b1 = new Buffer(45);
 		function get(pos, cb) {
-			fs.read(self._fd, b1, 0, 45, pos, safe.trap_sure(cb, function (bytes, data) {
+			fs.read(self._fd, b1, 0, 45, pos, safe.sure(cb, function (bytes, data) {
 				var h1 = JSON.parse(data.toString());
 				h1.o = parseInt(h1.o, 10);
 				h1.k = parseInt(h1.k, 10);
@@ -204,21 +204,19 @@ tcoll.prototype._compact = function (cb) {
 					cb();
 				}));
 			}));
-		}, function (err) {
-			if (err) {
-				fs.close(fd, function () {
-					fs.unlink(filename, function () {
-						cb(err);
-					});
-				});
-				return;
-			}
+		}, safe.sure(function (err) {
+			fs.close(fd, safe.sure(cb, function () {
+				fs.unlink(filename, safe.sure(cb, function () {
+					cb(err);
+				}));
+			}));
+		}, function () {
 			if (process.platform.match(/^win/)) {
 				// WINDOWS: unsafe because if something fail while renaming file it will not
 				// restore automatically
-				fs.close(self._fd, safe.sure(cb,function() {
-					fs.close(fd, safe.sure(cb,function() {
-						fs.unlink(self._filename, safe.sure(cb,function () {
+				fs.close(self._fd, safe.sure(cb, function () {
+					fs.close(fd, safe.sure(cb, function () {
+						fs.unlink(self._filename, safe.sure(cb, function () {
 							fs.rename(filename, self._filename, safe.sure(cb, function () {
 								fs.open(self._filename, 'a+', safe.sure(cb, function (fd) {
 									self._fd = fd;
@@ -233,14 +231,15 @@ tcoll.prototype._compact = function (cb) {
 			} else {
 				// safe way
 				fs.rename(filename, self._filename, safe.sure(cb, function () {
-					fs.close(self._fd);
-					self._fd = fd;
-					self._fsize = wpos;
-					self._store = store;
-					cb();
+					fs.close(self._fd, safe.sure(cb, function () {
+						self._fd = fd;
+						self._fsize = wpos;
+						self._store = store;
+						cb();
+					}));
 				}));
 			}
-		});
+		}));
 	}));
 };
 
@@ -367,12 +366,12 @@ tcoll.prototype._getFS = function (pos, unsafe, cb) {
 	if (cached)
 		return safe.back(cb,null,cached);
 	var b1 = new Buffer(45);
-	fs.read(self._fd, b1, 0, 45, pos, safe.trap_sure(cb, function (bytes, data) {
+	fs.read(self._fd, b1, 0, 45, pos, safe.sure(cb, function (bytes, data) {
 		var h1 = JSON.parse(data.toString());
 		h1.o = parseInt(h1.o,10);
 		h1.k = parseInt(h1.k,10);
 		var b2 = new Buffer(h1.o);
-		fs.read(self._fd,b2,0,h1.o,pos+45+2+h1.k, safe.trap_sure(cb, function (bytes, data) {
+		fs.read(self._fd, b2, 0, h1.o, pos + 45 + 2 + h1.k, safe.sure(cb, function (bytes, data) {
 			var obj = self._unwrapTypes(JSON.parse(data.toString()));
 			if (bytes <= self._cmaxobj)
 				self._cache.set(pos, obj);
@@ -1204,16 +1203,16 @@ tcoll.prototype.mapReduce = function (map, reduce, opts, cb) {
 		var doc;
 		safe.doUntil(
 			function (cb) {
-				c.nextObject(safe.trap_sure(cb, function (_doc) {
+				c.nextObject(safe.sure(cb, function (_doc) {
 					doc = _doc;
 					if (doc) map.call(doc);
-					return cb();
+					cb();
 				}));
 			},
 			function () {
 				return doc === null;
 			},
-			safe.trap_sure(cb, function () {
+			safe.sure(cb, function () {
 				_.each(m,function (v, k) {
 					v = v.length > 1 ? reduce(k, v) : v[0];
 					if (finalize) v = finalize(k, v);
@@ -1221,9 +1220,8 @@ tcoll.prototype.mapReduce = function (map, reduce, opts, cb) {
 				});
 
 				var stats = {};
-				if (opts.out.inline) return process.nextTick(function () {
-					cb(null, _.values(m), stats); // execute outside of trap
-				});
+				if (opts.out.inline)
+					return safe.back(cb, null, _.values(m), stats); // execute outside of trap
 
 				// write results to collection
 				safe.waterfall([

--- a/lib/tcursor.js
+++ b/lib/tcursor.js
@@ -124,7 +124,7 @@ tcursor.prototype.skip = function (v, cb) {
 	if (!self._err)
 		this._skip = v;
 	if (cb)
-		process.nextTick(function () {cb(self._err,self);});
+		safe.back(cb, self._err, self);
 	return this;
 };
 
@@ -175,7 +175,7 @@ tcursor.prototype.sort = function (v, d, cb) {
 		});
 	}
 	if (cb)
-		process.nextTick(function () {cb(self._err, self);});
+		safe.back(cb, self._err, self);
 	return this;
 };
 
@@ -193,14 +193,14 @@ tcursor.prototype.limit = function (v, cb) {
 		this._limit = v==0?null:Math.abs(v);
 	}
 	if (cb)
-		process.nextTick(function () {cb(self._err,self);});
+		safe.back(cb, self._err, self);
 	return this;
 };
 
 tcursor.prototype.nextObject = function (cb) {
 	var self = this;
 	if (self._err) {
-		if (cb) process.nextTick(function () {cb(self._err);});
+		if (cb) safe.back(cb, self._err);
 		return;
 	}
 	self._ensure(safe.sure(cb, function () {
@@ -218,7 +218,7 @@ tcursor.prototype.count = function (applySkipLimit, cb) {
 		applySkipLimit = false;
 	}
 	if (self._err) {
-		if (cb) process.nextTick(function () {cb(self._err);});
+		if (cb) safe.back(cb, self._err);
 		return;
 	}
 	if ((!self._skip && self._limit === null) || applySkipLimit) {
@@ -228,9 +228,7 @@ tcursor.prototype.count = function (applySkipLimit, cb) {
 		return;
 	}
 	if (self._count !== null) {
-		process.nextTick(function () {
-			cb(null, self._count);
-		});
+		safe.back(cb, null, self._count);
 		return;
 	}
 	self._c._find(self._query, {}, 0, null, null, self._hint, self._arFields, safe.sure(cb, function (data) {
@@ -242,7 +240,7 @@ tcursor.prototype.count = function (applySkipLimit, cb) {
 tcursor.prototype.setReadPreference = function (the, cb) {
 	var self = this;
 	if (self._err) {
-		if (cb) process.nextTick(function () {cb(self._err);});
+		if (cb) safe.back(cb, self._err);
 		return;
 	}
 	return this;
@@ -258,7 +256,7 @@ tcursor.prototype.batchSize = function (v, cb) {
 		self._err = new Error('Cursor is closed');
 		if (!cb) throw self._err;
 	}
-	if (cb) process.nextTick(function () {cb(self._err,self);});
+	if (cb) safe.back(cb, self._err, self);
 	return this;
 };
 
@@ -268,7 +266,7 @@ tcursor.prototype.close = function (cb) {
 	this._i=-1;
 	this._err = null;
 	if (cb)
-		process.nextTick(function () {cb(self._err,self);});
+		safe.back(cb, self._err, self);
 	return this;
 };
 
@@ -286,7 +284,7 @@ tcursor.prototype.toArray = function (cb) {
 		self._err = new Error("Cursor is closed");
 
 	if (self._err) {
-		if (cb) process.nextTick(function () {cb(self._err);});
+		if (cb) safe.back(cb, self._err);
 		return;
 	}
 
@@ -312,7 +310,7 @@ tcursor.prototype.each = function (cb) {
 		self._err = new Error("Cursor is closed");
 
 	if (self._err) {
-		if (cb) process.nextTick(function () {cb(self._err);});
+		if (cb) safe.back(cb, self._err);
 		return;
 	}
 	self._ensure(safe.sure(cb, function () {
@@ -335,7 +333,7 @@ tcursor.prototype.stream = function (options) {
 tcursor.prototype._ensure = function (cb) {
 	var self = this;
 	if (self._items!=null)
-		return process.nextTick(cb);
+		return safe.back(cb);
 	self._c._find(self._query, {}, self._skip, self._limit, self._sort, self._hint, self._arFields, safe.sure_result(cb, function (data) {
 		self._items = data;
 		self._i=0;

--- a/lib/tdb.js
+++ b/lib/tdb.js
@@ -121,14 +121,14 @@ tdb.prototype.collectionNames = function (opts, cb) {
 		opts = {};
 	}
 	if (this._stype=="mem") {
-		cb(null, _.map(self._mstore, function (v, e) { return opts.namesOnly?e:{name:self._name+"."+e};}));
+		cb(null, _.map(self._mstore, function (v, e) { return opts.namesOnly ? e : { name: self._name + "." + e }; }));
 	} else {
 		fs.readdir(self._path, safe.sure(cb,function(files) {
 			// some collections ca be on disk and some only in memory, we need both
-			files = _.union(files,_.keys(self._cols));
-			cb(null,_(files)
-				.reject(function (e) {return /^\./.test(e);}) // ignore hidden linux alike files
-				.map(function (e) { return opts.namesOnly?e:{name:self._name+"."+e};})
+			files = _(self._cols).keys().union(files);
+			cb(null, files
+				.reject(function (e) { return /^\./.test(e); }) // ignore hidden linux alike files
+				.map(function (e) { return opts.namesOnly ? e : { name: self._name + "." + e }; })
 				.value());
 		}));
 	}
@@ -151,7 +151,7 @@ tdb.prototype.dropCollection = function (cname, cb) {
 	if (!c) {
 		var err = new Error("ns not found");
 		if (cb) return safe.back(cb, err);
-			else throw new err;
+		throw new err;
 	}
 	c._stop(safe.sure(cb, function (ondisk) {
 		delete self._cols[cname];

--- a/lib/tstream.js
+++ b/lib/tstream.js
@@ -1,9 +1,5 @@
-var timers = require('timers');
 var _ = require('lodash');
 var safe = require('safe');
-
-// Set processor, setImmediate if 0.10 otherwise nextTick
-var processor = timers.setImmediate ? timers.setImmediate : process.nextTick;
 
 /**
  * Module dependecies.
@@ -41,7 +37,7 @@ function CursorStream(cursor, options) {
 
   // give time to hook up events
   var self = this;
-  process.nextTick(function() {
+  safe.back(function() {
     self._init();
   });
 }
@@ -82,7 +78,7 @@ CursorStream.prototype._next = function () {
 
   var self = this;
   // Get the next object
-  processor(function() {
+  safe.back(function() {
     if(self.paused || self._destroyed) return;
 
     self._cursor.nextObject(function (err, doc) {
@@ -132,7 +128,7 @@ CursorStream.prototype.resume = function () {
   if(!this.paused) return;
   //if(!this._cursor.state == 3) return;
 
-  process.nextTick(function() {
+  safe.back(function() {
     self.paused = false;
     // Only trigger more fetching if the cursor is open
     self._next();

--- a/lib/wqueue.js
+++ b/lib/wqueue.js
@@ -1,3 +1,5 @@
+var safe = require("safe");
+
 function wqueue (limit,first) {
 	this.limit = limit || 100;
 	this._rc = 0;
@@ -42,7 +44,7 @@ wqueue.prototype._exec = function (task,block,cb) {
 
 wqueue.prototype._ping = function () {
 	var self = this;
-	process.nextTick(function () {
+	safe.back(function () {
 		while (self._q.length>0 && self._rc<self.limit && !self._blocked && (!self._q[0].block || self._rc==0) ) {
 			var t = self._q.splice(0,1)[0];
 			if (self._stoped)

--- a/test/basic-test.js
+++ b/test/basic-test.js
@@ -18,19 +18,19 @@ describe('Basic', function () {
 			tutils.getDb('test', true, safe.sure(done, function (_db) {
 				db = _db;
 				done();
-			}))
-		})
+			}));
+		});
 		it("Create new collection", function (done) {
 			db.collection("test", {}, safe.sure(done,function (_coll) {
 				coll = _coll;
 				done();
-			}))
-		})
+			}));
+		});
 		it("Populated with test data", function (done) {
 			gt0sin = 0;
 			_dt = null;
 			var i=0;
-			safe.whilst(function () { return i<num},
+			safe.whilst(function () { return i<num;},
 				function (cb) {
 					var d;
 					if (!_dt) _dt = d = new Date();
@@ -39,22 +39,22 @@ describe('Basic', function () {
 					obj.txt = obj.sin > 0 && "больше нуля" || obj.sin < 0 && "меньше нуля" || "ноль";
 					coll.insert(obj, cb);
 					if (obj.sin>0 && obj.sin<0.5)
-					   gt0sin++;
+						gt0sin++;
 					i++;
 				},
 				done
-			)
-		})
+			);
+		});
 		it("Has right size", function (done) {
 			coll.count(safe.sure(done, function (count) {
 				assert.equal(count, num);
 				done();
-			}))
-		})
+			}));
+		});
 		after(function (done) {
 			db.close(done);
 		});
-	})
+	});
 	describe('Existing store', function () {
 		var db,coll;
 		before(function (done) {
@@ -65,19 +65,19 @@ describe('Basic', function () {
 					coll.ensureIndex({sin:1}, safe.sure(done, function () {
 						coll.ensureIndex({num:1}, safe.sure(done, function () {
 							coll.ensureIndex({_dt:1}, safe.sure(done, function () {
-								done()
-							}))
-						}))
-					}))
-				}))
-			}))
-		})
+								done();
+							}));
+						}));
+					}));
+				}));
+			}));
+		});
 		it("Has right size", function (done) {
 			coll.count(safe.sure(done, function (count) {
 				assert.equal(count, num);
 				done();
-			}))
-		})
+			}));
+		});
 		it("utf8 text", function (done) {
 			coll.find({ sin: { $gt: 0 } }).toArray(safe.sure(done, function (docs) {
 				docs.forEach(function (doc) {
@@ -93,15 +93,15 @@ describe('Basic', function () {
 				assert.equal(docs.length, 1);
 				assert.equal(_.isDate(docs[0]._dt),true);
 				done();
-			}))
-		})
+			}));
+		});
 		it("find date", function (done) {
 			coll.find({"_dt":_dt}).toArray(safe.sure(done, function (docs) {
 				assert.equal(docs.length, 1);
 				assert.equal(docs[0]._dt.toString(), _dt.toString());
 				done();
-			}))
-		})
+			}));
+		});
 		it("find date range", function (done) {
 			var start = new Date(_dt.getTime() + 5000);
 			var end = new Date(start.getTime() + 20000);
@@ -121,11 +121,11 @@ describe('Basic', function () {
 		it("find ObjectID", function (done) {
 			coll.find({"_id":_id}).toArray(safe.sure(done, function (docs) {
 				assert.equal(1,docs.length);
-				assert.equal(docs[0]._id.constructor.name == "ObjectID",true)
+				assert.equal(docs[0]._id.constructor.name == "ObjectID",true);
 				assert.equal(docs[0]._id.toString(), _id.toString());
 				done();
-			}))
-		})
+			}));
+		});
 		it("find by two index fields", function (done) {
 			coll.find({num:{$lt:30},sin:{$lte:0}}).toArray(safe.sure(done, function (docs) {
 				assert.equal(docs.length, 15);
@@ -136,63 +136,63 @@ describe('Basic', function () {
 			coll.find({sin:{$gt:0,$lt:0.5},t:15}).toArray(safe.sure(done, function (docs) {
 				assert.equal(docs.length, gt0sin);
 				done();
-			}))
-		})
+			}));
+		});
 		it("sort ascending no index", function (done) {
 			coll.find({num:{$lt:11}}).sort({num:1}).toArray(safe.sure(done, function (docs) {
 				assert.equal(docs.length, 11);
 				assert.equal(docs[0].num,0);
 				done();
-			}))
-		})
+			}));
+		});
 		it("sort descending no index", function (done) {
 			coll.find({num:{$lt:11}}).sort({num:-1}).toArray(safe.sure(done, function (docs) {
 				assert.equal(docs.length, 11);
 				assert.equal(docs[0].num,10);
 				done();
-			}))
-		})
+			}));
+		});
 		it("sort ascending with index", function (done) {
 			coll.find({pum:{$lt:11}}).sort({num:1}).toArray(safe.sure(done, function (docs) {
 				assert.equal(docs.length, 11);
 				assert.equal(docs[0].num,0);
 				done();
-			}))
-		})
+			}));
+		});
 		it("sort descending with index", function (done) {
 			coll.find({pum:{$lt:11}}).sort({num:-1}).toArray(safe.sure(done, function (docs) {
 				assert.equal(docs.length, 11);
 				assert.equal(docs[0].num,10);
 				done();
-			}))
-		})
+			}));
+		});
 		it("find with exclude fields {junk:0}", function (done) {
 			coll.find({num:10},{junk:0}).toArray(safe.sure(done, function (docs) {
 				assert.equal(docs[0].junk, null);
 				done();
-			}))
-		})
+			}));
+		});
 		it("find with exclude fields {'sub.num':0,junk:0}", function (done) {
 			coll.find({num:10},{'sub.num':0,junk:0}).toArray(safe.sure(done, function (docs) {
 				assert.equal(docs[0].junk, null);
 				assert.equal(docs[0].sub.num, null);
 				done();
-			}))
-		})
+			}));
+		});
 		it("find with fields {'num':1}", function (done) {
 			coll.find({num:10},{'num':1}).toArray(safe.sure(done, function (docs) {
 				assert.equal(_.size(docs[0]),2);
 				assert.equal(docs[0].num, 10);
 				done();
-			}))
-		})
+			}));
+		});
 		it("find with fields {'sub.num':1}", function (done) {
 			coll.find({num:10},{'sub.num':1}).toArray(safe.sure(done, function (docs) {
 				assert.equal(_.size(docs[0]),2);
 				assert.equal(docs[0].sub.num, 10);
 				done();
-			}))
-		})
+			}));
+		});
 		it("dummy update", function (done) {
 			coll.update({pum:11},{$set:{num:10,"sub.tub":10,"sub.num":10},$unset:{sin:1}}, safe.sure(done, function () {
 				coll.find({pum:11}).toArray(safe.sure(done, function (docs) {
@@ -204,9 +204,9 @@ describe('Basic', function () {
 					assert.equal(obj.sub.tub, 10);
 					assert.equal(obj.sin,null);
 					done();
-				}))
-			}))
-		})
+				}));
+			}));
+		});
 		it("$unset and $inc on subfields", function (done) {
 			coll.update({pum:11},{$unset:{"sub.tub":1}, $inc:{"sub.num": 5, "sub.pum": 3}}, safe.sure(done, function () {
 				coll.find({pum:11}).toArray(safe.sure(done, function (docs) {
@@ -227,16 +227,16 @@ describe('Basic', function () {
 					assert.equal(docs[0].num,2);
 					assert.equal(docs[1].num,3);
 					done();
-				}))
-			}))
-		})
+				}));
+			}));
+		});
 		it("dummy remove", function (done) {
 			coll.remove({pum:20}, safe.sure(done, function () {
-				coll.findOne({pum:20},done)
-			}))
-		})
+				coll.findOne({pum:20},done);
+			}));
+		});
 		after(function (done) {
 			db.close(done);
 		});
-	})
-})
+	});
+});

--- a/test/contrib/cursor_tests.js
+++ b/test/contrib/cursor_tests.js
@@ -1,5 +1,4 @@
-var Step = require('step')
-  fs = require('fs');
+var Step = require('step');
 
 /**
  * An example showing the information returned by indexInformation
@@ -33,7 +32,7 @@ exports.shouldCorrectlyExecuteToArray = function(configuration, test) {
     });
   });
   // DOC_END
-}
+};
 
 /**
  * @ignore
@@ -61,7 +60,7 @@ exports.shouldCorrectlyExecuteToArrayAndFailOnFurtherCursorAccess = function(con
       });
     });
   });
-}
+};
 
 /**
  * A simple example iterating over a query using the each function of the cursor.
@@ -102,13 +101,13 @@ exports.shouldCorrectlyFailToArrayDueToFinishedEachOperation = function(configur
               test.done();
               db.close();
             });
-          };
+          }
         });
       });
     });
   });
   // DOC_END
-}
+};
 
 /**
  * @ignore
@@ -186,10 +185,10 @@ exports.shouldCorrectlyExecuteCursorCount = function(configuration, test) {
             test.equal(0, count);
           });
         }
-      )
+      );
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -255,7 +254,7 @@ exports.shouldCorrectlyExecuteSortOnCursor = function(configuration, test) {
       }
     );
   });
-}
+};
 
 /**
  * @ignore
@@ -281,9 +280,9 @@ exports.shouldCorrectlyThrowErrorOnToArrayWhenMissingCallback = function(configu
           test.done();
         });
       }
-    )
+    );
   });
-}
+};
 
 /**
  * @ignore
@@ -309,9 +308,9 @@ exports.shouldThrowErrorOnEachWhenMissingCallback = function(configuration, test
           test.done();
         });
       }
-    )
+    );
   });
-}
+};
 
 /**
  * @ignore
@@ -342,7 +341,7 @@ exports.shouldCorrectlyHandleLimitOnCursor = function(configuration, test) {
       }
     );
   });
-}
+};
 
 /**
  * @ignore
@@ -369,7 +368,7 @@ exports.shouldCorrectlyHandleNegativeOneLimitOnCursor = function(configuration, 
       }
     );
   });
-}
+};
 
 /**
  * @ignore
@@ -396,7 +395,7 @@ exports.shouldCorrectlyHandleAnyNegativeLimitOnCursor = function(configuration, 
       }
     );
   });
-}
+};
 
 /**
  * @ignore
@@ -450,7 +449,7 @@ exports.shouldCorrectlyReturnErrorsOnIllegalLimitValues = function(configuration
       });
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -497,9 +496,9 @@ exports.shouldCorrectlySkipRecordsOnCursor = function(configuration, test) {
           });
         });
       }
-    )
+    );
   });
-}
+};
 
 /**
  * @ignore
@@ -513,14 +512,14 @@ exports.shouldCorrectlyReturnErrorsOnIllegalSkipValues = function(configuration,
       test.equal("skip requires an integer", err.message);
     });
 
-    var cursor = collection.find()
+    var cursor = collection.find();
     cursor.nextObject(function(err, doc) {
       cursor.skip(1, function(err, cursor) {
         test.equal("Cursor is closed", err.message);
       });
     });
 
-    var cursor = collection.find()
+    cursor = collection.find();
     cursor.close(function(err, cursor) {
       cursor.skip(1, function(err, cursor) {
         test.equal("Cursor is closed", err.message);
@@ -529,7 +528,7 @@ exports.shouldCorrectlyReturnErrorsOnIllegalSkipValues = function(configuration,
       });
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -551,7 +550,7 @@ exports.shouldReturnErrorsOnIllegalBatchSizes = function(configuration, test) {
       test.equal("batchSize requires an integer", err.message);
     }
 
-    var cursor = collection.find();
+    cursor = collection.find();
     cursor.nextObject(function(err, doc) {
       cursor.nextObject(function(err, doc) {
         cursor.batchSize(1, function(err, cursor) {
@@ -567,7 +566,7 @@ exports.shouldReturnErrorsOnIllegalBatchSizes = function(configuration, test) {
       });
     });
 
-    var cursor = collection.find()
+    cursor = collection.find();
     cursor.close(function(err, cursor) {
       cursor.batchSize(1, function(err, cursor) {
         test.equal("Cursor is closed", err.message);
@@ -583,7 +582,7 @@ exports.shouldReturnErrorsOnIllegalBatchSizes = function(configuration, test) {
       }
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -781,9 +780,9 @@ exports.shouldHandleSkipLimitChaining = function(configuration, test) {
           });
         });
       }
-    )
+    );
   });
-}
+};
 
 /**
  * @ignore
@@ -822,9 +821,9 @@ exports.shouldCorrectlyHandleLimitSkipChainingInline = function(configuration, t
           });
         });
       }
-    )
+    );
   });
-}
+};
 
 /**
  * @ignore
@@ -839,7 +838,7 @@ exports.shouldCloseCursorNoQuerySent = function(configuration, test) {
       test.done();
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -867,7 +866,7 @@ exports.shouldCorrectlyExecuteToArrayAndFailOnFurtherCursorAccess = function(con
       });
     });
   });
-}
+};
 
 /**
  * A simple example iterating over a query using the each function of the cursor.
@@ -908,13 +907,13 @@ exports.shouldCorrectlyFailToArrayDueToFinishedEachOperation = function(configur
               test.done();
               db.close();
             });
-          };
+          }
         });
       });
     });
   });
   // DOC_END
-}
+};
 
 /**
  * @ignore
@@ -960,7 +959,7 @@ exports.shouldCorrectlyExecuteCursorCountWithFields = function(configuration, te
       });
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -978,7 +977,7 @@ exports.shouldCorrectlyCountWithFieldsUsingExclude = function(configuration, tes
       });
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -988,7 +987,7 @@ exports.shouldCorrectlyExecuteEnsureIndexWithNoCallback = function(configuration
   var docs = [];
 
   for(var i = 0; i < 1; i++) {
-    var d = new Date().getTime() + i*1000;
+    var d = Date.now() + i*1000;
     docs[i] = {createdAt:new Date(d)};
   }
 
@@ -996,7 +995,7 @@ exports.shouldCorrectlyExecuteEnsureIndexWithNoCallback = function(configuration
   // Create collection
   client.createCollection('shouldCorrectlyExecuteEnsureIndexWithNoCallback', function(err, collection) {
     // ensure index of createdAt index
-    collection.ensureIndex({createdAt:1})
+    collection.ensureIndex({createdAt:1});
     // insert all docs
     collection.insert(docs, {w:1}, function(err, result) {
       test.equal(null, err);
@@ -1006,10 +1005,10 @@ exports.shouldCorrectlyExecuteEnsureIndexWithNoCallback = function(configuration
         if (err) logger.error("error in collection_info.find: " + err);
         test.equal(1, items.length);
         test.done();
-      })
-    })
+      });
+    });
   });
-}
+};
 
 /**
  * @ignore
@@ -1019,7 +1018,7 @@ exports.shouldCorrectlyInsert5000RecordsWithDateAndSortCorrectlyWithIndex = func
   var docs = [];
 
   for(var i = 0; i < 5000; i++) {
-    var d = new Date().getTime() + i*1000;
+    var d = Date.now() + i*1000;
     docs[i] = {createdAt:new Date(d)};
   }
 
@@ -1039,11 +1038,11 @@ exports.shouldCorrectlyInsert5000RecordsWithDateAndSortCorrectlyWithIndex = func
           if (err) logger.error("error in collection_info.find: " + err);
           test.equal(5000, items.length);
           test.done();
-        })
-      })
+        });
+      });
     });
   });
-}
+};
 
 /**
  * An example showing the information returned by indexInformation
@@ -1063,7 +1062,7 @@ exports['Should correctly rewind and restart cursor'] = function(configuration, 
 
     // Insert 100 documents with some data
     for(var i = 0; i < 100; i++) {
-      var d = new Date().getTime() + i*1000;
+      var d = Date.now() + i*1000;
       docs[i] = {'a':i, createdAt:new Date(d)};
     }
 
@@ -1106,7 +1105,7 @@ exports['Should correctly execute count on cursor'] = function(configuration, te
   var docs = [];
 
   for(var i = 0; i < 1000; i++) {
-    var d = new Date().getTime() + i*1000;
+    var d = Date.now() + i*1000;
     docs[i] = {'a':i, createdAt:new Date(d)};
   }
 
@@ -1131,13 +1130,13 @@ exports['Should correctly execute count on cursor'] = function(configuration, te
               test.equal(1000, c);
               test.equal(1000, total);
               test.done();
-            })
+            });
           }
         });
-      })
-    })
+      });
+    });
   });
-}
+};
 
 
 /**
@@ -1187,7 +1186,7 @@ exports['should be able to stream documents'] = function(configuration, test) {
           setTimeout(function () {
             test.equal(true, stream.paused);
             stream.resume();
-            process.nextTick(function() {
+            safe.back(function() {
               test.equal(false, stream.paused);
               resumed++;
             })
@@ -1448,12 +1447,12 @@ exports.shouldCorrectlyUseCursorCountFunction = function(configuration, test) {
 
           db.close();
           test.done();
-        })
+        });
       });
     });
   });
   // DOC_END
-}
+};
 
 /**
  * A simple example showing the use of sort on the cursor.
@@ -1496,7 +1495,7 @@ exports.shouldCorrectlyPeformSimpleSorts = function(configuration, test) {
     });
   });
   // DOC_END
-}
+};
 
 /**
  * A simple example showing the use of limit on the cursor
@@ -1533,7 +1532,7 @@ exports.shouldCorrectlyPeformLimitOnCursor = function(configuration, test) {
     });
   });
   // DOC_END
-}
+};
 
 /**
  * A simple example showing the use of skip on the cursor
@@ -1570,7 +1569,7 @@ exports.shouldCorrectlyPeformSkipOnCursor = function(configuration, test) {
     });
   });
   // DOC_END
-}
+};
 
 /**
  * A simple example showing the use of batchSize on the cursor, batchSize only regulates how many
@@ -1608,7 +1607,7 @@ exports.shouldCorrectlyPeformBatchSizeOnCursor = function(configuration, test) {
     });
   });
   // DOC_END
-}
+};
 
 /**
  * A simple example showing the use of nextObject.
@@ -1645,7 +1644,7 @@ exports.shouldCorrectlyPeformNextObjectOnCursor = function(configuration, test) 
     });
   });
   // DOC_END
-}
+};
 
 /**
  * A simple example showing the use of the cursor explain function.
@@ -1795,9 +1794,9 @@ exports.shouldStreamDocumentsUsingTheCloseFunction = function(configuration, tes
   db.open(function(err, db) {
 
     // Create a lot of documents to insert
-    var docs = []
+    var docs = [];
     for(var i = 0; i < 100; i++) {
-      docs.push({'a':i})
+      docs.push({'a':i});
     }
 
     // Create a collection
@@ -1825,7 +1824,7 @@ exports.shouldStreamDocumentsUsingTheCloseFunction = function(configuration, tes
     });
   });
   // DOC_END
-}
+};
 
 /**
  * @ignore
@@ -2050,21 +2049,17 @@ exports.shouldNotFailDueToStackOverflowEach = function(configuration, test) {
     for(var i = 0; i < 30000; i++) docs.push({a:i});
 
     collection.insert(docs, {w:1}, function(err, ids) {
-      var s = new Date().getTime();
-
       collection.find({}).each(function(err, item) {
         if(item == null) {
-          var e = new Date().getTime();
-
           test.equal(30000, total);
           test.done();
         }
 
         total++;
-      })
+      });
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -2074,23 +2069,18 @@ exports.shouldNotFailDueToStackOverflowToArray = function(configuration, test) {
   var client = configuration.db();
   client.createCollection('shouldNotFailDueToStackOverflowToArray', function(err, collection) {
     var docs = [];
-    var total = 0;
-    var s = new Date().getTime();
     for(var i = 0; i < 30000; i++) docs.push({a:i});
 
     collection.insert(docs, {w:1}, function(err, ids) {
-      var s = new Date().getTime();
-
       collection.find({}).toArray(function(err, items) {
-        var e = new Date().getTime();
         // console.log("================== total time :: " + (e - s));
 
         test.equal(30000, items.length);
         test.done();
-      })
+      });
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -2098,7 +2088,7 @@ exports.shouldNotFailDueToStackOverflowToArray = function(configuration, test) {
  */
 exports.shouldCorrectlySkipAndLimit = function(configuration, test) {
   var client = configuration.db();
-  var collection = client.collection('shouldCorrectlySkipAndLimit')
+  var collection = client.collection('shouldCorrectlySkipAndLimit');
   var docs = [];
   for(var i = 0; i < 100; i++) docs.push({a:i, OrderNumber:i});
 
@@ -2111,9 +2101,9 @@ exports.shouldCorrectlySkipAndLimit = function(configuration, test) {
         test.equal(10, count);
         test.done();
       });
-    })
+    });
   });
-}
+};
 
 /**
  * @ignore

--- a/test/contrib/cursorstream_tests.js
+++ b/test/contrib/cursorstream_tests.js
@@ -1,4 +1,5 @@
 var Buffer = require("safe-buffer").Buffer;
+var safe = require("safe");
 /**
  * A simple example showing the use of the cursorstream pause function.
  *
@@ -15,9 +16,9 @@ exports.shouldStreamDocumentsUsingTheCursorStreamPauseFunction = function(config
   db.open(function(err, db) {
 
     // Create a lot of documents to insert
-    var docs = []
+    var docs = [];
     for(var i = 0; i < 1; i++) {
-      docs.push({'a':i})
+      docs.push({'a':i});
     }
 
     // Create a collection
@@ -42,9 +43,9 @@ exports.shouldStreamDocumentsUsingTheCursorStreamPauseFunction = function(config
           setTimeout(function() {
             stream.resume();
             // Check if cursor is paused
-            process.nextTick(function() {
+            safe.back(function() {
               test.equal(false, stream.paused);
-            })
+            });
           }, 1);
         });
 
@@ -57,7 +58,7 @@ exports.shouldStreamDocumentsUsingTheCursorStreamPauseFunction = function(config
     });
   });
   // DOC_END
-}
+};
 
 /**
  * A simple example showing the use of the cursorstream resume function.
@@ -75,9 +76,9 @@ exports.shouldStreamDocumentsUsingTheCursorStreamResumeFunction = function(confi
   db.open(function(err, db) {
 
     // Create a lot of documents to insert
-    var docs = []
+    var docs = [];
     for(var i = 0; i < 1; i++) {
-      docs.push({'a':i})
+      docs.push({'a':i});
     }
 
     // Create a collection
@@ -105,7 +106,7 @@ exports.shouldStreamDocumentsUsingTheCursorStreamResumeFunction = function(confi
             stream.resume();
 
             // Check if cursor is paused
-            process.nextTick(function() {
+            safe.back(function() {
               test.equal(false, stream.paused);
             });
           }, 1);
@@ -120,7 +121,7 @@ exports.shouldStreamDocumentsUsingTheCursorStreamResumeFunction = function(confi
     });
   });
   // DOC_END
-}
+};
 
 /**
  * A simple example showing the use of the cursorstream resume function.
@@ -138,9 +139,9 @@ exports.shouldStreamDocumentsUsingTheCursorStreamDestroyFunction = function(conf
   db.open(function(err, db) {
 
     // Create a lot of documents to insert
-    var docs = []
+    var docs = [];
     for(var i = 0; i < 1; i++) {
-      docs.push({'a':i})
+      docs.push({'a':i});
     }
 
     // Create a collection
@@ -167,13 +168,13 @@ exports.shouldStreamDocumentsUsingTheCursorStreamDestroyFunction = function(conf
     });
   });
   // DOC_END
-}
+};
 
 exports.shouldStreamDocumentsWithPauseAndResumeForFetching = function(configuration, test) {
-  var docs = []
+  var docs = [];
 
   for(var i = 0; i < 3000; i++) {
-    docs.push({'a':i})
+    docs.push({'a':i});
   }
 
   var db = configuration.newDbInstance({w:0}, {poolSize:1});
@@ -189,12 +190,12 @@ exports.shouldStreamDocumentsWithPauseAndResumeForFetching = function(configurat
 
         // For each data item
         stream.on("data", function(item) {
-          stream.pause()
+          stream.pause();
 
           collection.findOne({}, function(err, result) {
             data.push(1);
             stream.resume();
-          })
+          });
         });
 
         // When the stream is done
@@ -206,14 +207,14 @@ exports.shouldStreamDocumentsWithPauseAndResumeForFetching = function(configurat
       });
     });
   });
-}
+};
 
 exports.shouldStream10KDocuments = function(configuration, test) {
   var Binary = configuration.getMongoPackage().Binary;
-  var docs = []
+  var docs = [];
 
   for(var i = 0; i < 10000; i++) {
-    docs.push({'a':i, bin: new Binary(new Buffer(256))})
+    docs.push({'a':i, bin: new Binary(new Buffer(256))});
   }
 
   var db = configuration.newDbInstance({w:0}, {poolSize:1});
@@ -229,12 +230,12 @@ exports.shouldStream10KDocuments = function(configuration, test) {
 
         // For each data item
         stream.on("data", function(item) {
-          stream.pause()
+          stream.pause();
 
           collection.findOne({}, function(err, result) {
             data.push(1);
             stream.resume();
-          })
+          });
         });
 
         // When the stream is done
@@ -246,16 +247,16 @@ exports.shouldStream10KDocuments = function(configuration, test) {
       });
     });
   });
-}
+};
 
 exports.shouldTriggerMassiveAmountOfGetMores = function(configuration, test) {
   var Binary = configuration.getMongoPackage().Binary;
-  var docs = []
+  var docs = [];
   var counter = 0;
   var counter2 = 0;
 
   for(var i = 0; i < 1000; i++) {
-    docs.push({'a':i, bin: new Binary(new Buffer(256))})
+    docs.push({'a':i, bin: new Binary(new Buffer(256))});
   }
 
   var db = configuration.newDbInstance({w:0}, {poolSize:1});
@@ -267,12 +268,11 @@ exports.shouldTriggerMassiveAmountOfGetMores = function(configuration, test) {
       collection.insert(docs, {w:1}, function(err, ids) {
         // Peform a find to get a cursor
         var stream = collection.find({}).stream();
-        var data = [];
 
         // For each data item
         stream.on("data", function(item) {
           counter++;
-          stream.pause()
+          stream.pause();
           stream.resume();
           counter2++;
         });
@@ -287,16 +287,15 @@ exports.shouldTriggerMassiveAmountOfGetMores = function(configuration, test) {
       });
     });
   });
-}
+};
 
 exports.shouldStreamDocumentsAcrossGetMoreCommandAndCountCorrectly = function(configuration, test) {
-  var ObjectID = configuration.getMongoPackage().ObjectID
-    , Binary = configuration.getMongoPackage().Binary;
+  var Binary = configuration.getMongoPackage().Binary;
   var client = configuration.db();
-  var docs = []
+  var docs = [];
 
   for(var i = 0; i < 2000; i++) {
-    docs.push({'a':i, b: new Binary(new Buffer(1024))})
+    docs.push({'a':i, b: new Binary(new Buffer(1024))});
   }
 
   var collection = client.collection('test_streaming_function_with_limit_for_fetching');
@@ -314,7 +313,7 @@ exports.shouldStreamDocumentsAcrossGetMoreCommandAndCountCorrectly = function(co
         test.equal(2000, doc.count);
 
         test.done();
-      })
+      });
     });
 
     stream.on('data',function(data){
@@ -325,4 +324,4 @@ exports.shouldStreamDocumentsAcrossGetMoreCommandAndCountCorrectly = function(co
       });
     });
   });
-}
+};

--- a/test/contrib/find_tests.js
+++ b/test/contrib/find_tests.js
@@ -1,4 +1,4 @@
-var Buffer = require("safe-buffer").Buffer;
+var safe = require("safe");
 
 /**
  * Test a simple find
@@ -8,7 +8,7 @@ exports.shouldCorrectlyPerformSimpleFind = function(configuration, test) {
   var client = configuration.db();
 
   client.createCollection('test_find_simple', function(err, r) {
-    var collection = client.collection('test_find_simple', function(err, collection) {
+    client.collection('test_find_simple', function(err, collection) {
       var doc1 = null;
 
       // Insert some test documents
@@ -34,7 +34,7 @@ exports.shouldCorrectlyPerformSimpleFind = function(configuration, test) {
       });
     });
   });
-}
+};
 
 /**
  * Test a simple find chained
@@ -43,7 +43,7 @@ exports.shouldCorrectlyPerformSimpleFind = function(configuration, test) {
 exports.shouldCorrectlyPeformSimpleChainedFind = function(configuration, test) {
   var client = configuration.db();
   client.createCollection('test_find_simple_chained', function(err, r) {
-    var collection = client.collection('test_find_simple_chained', function(err, collection) {
+    client.collection('test_find_simple_chained', function(err, collection) {
       var doc1 = null;
 
       // Insert some test documents
@@ -69,7 +69,7 @@ exports.shouldCorrectlyPeformSimpleChainedFind = function(configuration, test) {
       });
     });
   });
-}
+};
 
 /**
  * Test advanced find
@@ -78,7 +78,7 @@ exports.shouldCorrectlyPeformSimpleChainedFind = function(configuration, test) {
 exports.shouldCorrectlyPeformAdvancedFinds = function(configuration, test) {
   var client = configuration.db();
   client.createCollection('test_find_advanced', function(err, r) {
-    var collection = client.collection('test_find_advanced', function(err, collection) {
+    client.collection('test_find_advanced', function(err, collection) {
 
       // Insert some test documents
       collection.insert([{a:1}, {a:2}, {b:3}], {w:1}, function(err, docs) {
@@ -154,7 +154,7 @@ exports.shouldCorrectlyPeformAdvancedFinds = function(configuration, test) {
       });
     });
   });
-}
+};
 
 /**
  * Test sorting of results
@@ -249,7 +249,7 @@ exports.shouldCorrectlyPerformFindWithSort = function(configuration, test) {
       });
     });
   });
-}
+};
 
 /**
  * Test the limit function of the db
@@ -295,7 +295,7 @@ exports.shouldCorrectlyPerformFindWithLimit = function(configuration, test) {
       });
     });
   });
-}
+};
 
 /**
  * Test find by non-quoted values (issue #128)
@@ -316,7 +316,7 @@ exports.shouldCorrectlyFindWithNonQuotedValues = function(configuration, test) {
       });
     });
   });
-}
+};
 
 /**
  * Test for querying embedded document using dot-notation (issue #126)
@@ -347,7 +347,7 @@ exports.shouldCorrectlyFindEmbeddedDocument = function(configuration, test) {
       });
     });
   });
-}
+};
 
 /**
  * Find no records
@@ -364,7 +364,7 @@ exports.shouldCorrectlyFindNoRecords = function(configuration, test) {
       });
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -392,7 +392,7 @@ exports.shouldCorrectlyPerformFindByWhere = function(configuration, test) {
       });
     });
   });
-}
+};
 
 
 /**
@@ -471,7 +471,7 @@ exports.shouldCorrectlyPerformFindByObjectID = function(configuration, test) {
       });
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -501,7 +501,7 @@ exports.shouldCorrectlyReturnDocumentWithOriginalStructure= function(configurati
       });
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -522,7 +522,7 @@ exports.shouldCorrectlyRetrieveSingleRecord = function(configuration, test) {
       });
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -540,7 +540,7 @@ exports.shouldCorrectlyHandleError = function(configuration, test) {
       test.done();
     }
   });
-}
+};
 
 /**
  * Test field select with options
@@ -550,7 +550,7 @@ exports.shouldCorrectlyPerformFindWithOptions = function(configuration, test) {
   var client = configuration.db();
 
   client.createCollection('test_field_select_with_options', function(err, r) {
-    var collection = client.collection('test_field_select_with_options', function(err, collection) {
+    client.collection('test_field_select_with_options', function(err, collection) {
       var docCount = 25, docs = [];
 
       // Insert some test documents
@@ -578,7 +578,7 @@ exports.shouldCorrectlyPerformFindWithOptions = function(configuration, test) {
       });
     });
   });
-}
+};
 
 /**
  * Test findAndModify a document
@@ -624,14 +624,14 @@ exports.shouldCorrectlyFindAndModifyDocument = function(configuration, test) {
                     });
                   });
                 });
-              })
+              });
             });
-          })
+          });
         });
-      })
+      });
     });
   });
-}
+};
 
 /**
  * Test findAndModify a document with fields
@@ -650,7 +650,7 @@ exports.shouldCorrectlyFindAndModifyDocumentAndReturnSelectedFieldsOnly = functi
       });
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -786,7 +786,7 @@ exports['Should Correctly Handle FindAndModify Duplicate Key Error'] = function(
       });
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -797,11 +797,11 @@ exports['Should correctly return null when attempting to modify a non-existing d
     // Let's modify the document in place
     collection.findAndModify({name: 'test1'}, [], {$set: {name: 'test2'}}, {}, function(err, updated_doc) {
       test.equal(null, updated_doc);
-      test.ok(err == null || err.errmsg.match("No matching object found"))
+      test.ok(err == null || err.errmsg.match("No matching object found"));
       test.done();
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -814,12 +814,12 @@ exports['Should correctly handle chained skip and limit on find with toArray'] =
       collection.find().skip(1).limit(-1).toArray(function(err, items) {
         test.equal(null, err);
         test.equal(1, items.length);
-        test.equal(2, items[0].b)
+        test.equal(2, items[0].b);
         test.done();
-      })
+      });
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -832,14 +832,14 @@ exports['Should correctly handle chained skip and negative limit on find with to
       collection.find().skip(1).limit(-3).toArray(function(err, items) {
         test.equal(null, err);
         test.equal(3, items.length);
-        test.equal(2, items[0].b)
-        test.equal(3, items[1].c)
-        test.equal(4, items[2].d)
+        test.equal(2, items[0].b);
+        test.equal(3, items[1].c);
+        test.equal(4, items[2].d);
         test.done();
-      })
+      });
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -859,7 +859,7 @@ exports['Should correctly pass timeout options to cursor'] = function(configurat
 
     test.done();
   });
-}
+};
 
 /**
  * Test findAndModify a document with strict mode enabled
@@ -873,15 +873,15 @@ exports.shouldCorrectlyFindAndModifyDocumentWithDBStrict = function(configuratio
       collection.insert({'a':2, 'b':2}, {w:1}, function(err, doc) {
         // Let's modify the document in place
         collection.findAndModify({'a':2}, [['a', 1]], {'$set':{'b':3}}, {new:true}, function(err, result) {
-          test.equal(2, result.a)
-          test.equal(3, result.b)
+          test.equal(2, result.a);
+          test.equal(3, result.b);
           p_client.close();
           test.done();
-        })
+        });
       });
     });
   });
-}
+};
 
 /**
  * Test findAndModify a document that fails in first step before safe
@@ -900,11 +900,11 @@ exports.shouldCorrectlyFindAndModifyDocumentThatFailsInFirstStep = function(conf
           test.equal(null, result);
           test.ok(err.errmsg.match("duplicate key error index"));
           test.done();
-        })
+        });
       });
     });
   });
-}
+};
 
 /**
  * Test findAndModify a document that fails in first step before safe
@@ -954,10 +954,10 @@ exports['Should correctly return new modified document'] = function(configuratio
         test.equal(doc.c.b, item.c.b);
         test.equal(100, item.c.c);
         test.done();
-      })
+      });
     });
   });
-}
+};
 
 /**
  * Should correctly execute findAndModify that is breaking in prod
@@ -1024,7 +1024,7 @@ exports['Should Correctly find a Document using findOne excluding _id field'] = 
   var p_client = configuration.newDbInstance({w:1}, {poolSize:1, auto_reconnect:false});
   p_client.open(function(err, p_client) {
     p_client.createCollection('Should_Correctly_find_a_Document_using_findOne_excluding__id_field', function(err, collection) {
-      var doc = {_id : new ObjectID(), a:1, c:2}
+      var doc = {_id : new ObjectID(), a:1, c:2};
       // insert doc
       collection.insert(doc, {w:1}, function(err, result) {
         // Get one document, excluding the _id field
@@ -1034,18 +1034,18 @@ exports['Should Correctly find a Document using findOne excluding _id field'] = 
           test.equal(2, item.c);
 
           collection.find({a:1}, {fields:{'_id':0}}).toArray(function(err, items) {
-            var item = items[0]
+            var item = items[0];
             test.equal(null, item._id);
             test.equal(1, item.a);
             test.equal(2, item.c);
             p_client.close();
             test.done();
-          })
-        })
+          });
+        });
       });
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -1110,7 +1110,7 @@ exports.shouldCorrectlyHandlerErrorForFindAndModifyWhenNoRecordExists = function
       test.done();
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -1123,7 +1123,7 @@ exports.shouldCorrectlyExecuteFindAndModifyShouldGenerateCorrectBSON = function(
   transaction.document.type = "documentType";
   transaction.document.id = new ObjectID();
   transaction.transactionId = new ObjectID();
-  transaction.amount = 12.3333
+  transaction.amount = 12.3333;
 
   var transactions = [];
   transactions.push(transaction);
@@ -1134,22 +1134,22 @@ exports.shouldCorrectlyExecuteFindAndModifyShouldGenerateCorrectBSON = function(
     },
 
     transactions:transactions
-  }
+  };
 
   client.createCollection('shouldCorrectlyExecuteFindAndModify', function(err, collection) {
     collection.insert(wrapingObject, {w:1}, function(err, doc) {
       test.equal(null, err);
 
       collection.findOne({_id:doc[0]._id, 'funds.remaining': {$gte: 3.0}, 'transactions.id': {$ne: transaction.transactionId}}, function(err, item) {
-        test.ok(item != null)
+        test.ok(item != null);
 
         collection.findAndModify({_id:doc[0]._id, 'funds.remaining': {$gte: 3.0}, 'transactions.id': {$ne: transaction.transactionId}}, [], {$push: {transactions: transaction}}, {new: true, safe: true}, function(err, result) {
           test.done();
         });
-      })
+      });
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -1169,7 +1169,7 @@ exports.shouldCorrectlyExecuteMultipleFindsInParallel = function(configuration, 
             test.done();
             p_client.close();
           }
-        })
+        });
 
         collection.find({"user_id":"4e9fc8d55883d90100000003","lc_status":{"$ne":"deleted"},"owner_rating":{"$exists":false}},
           {"skip":0,"limit":10,"sort":{"updated":-1}}).count(function(err, count) {
@@ -1178,11 +1178,11 @@ exports.shouldCorrectlyExecuteMultipleFindsInParallel = function(configuration, 
             test.done();
             p_client.close();
           }
-        })
+        });
       });
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -1239,14 +1239,14 @@ exports.shouldCorrectlyExecuteFindAndModifyUnderConcurrentLoad = function(config
     p_client.collection("collection2", function(err, collection) {
       // Keep hammering in inserts
       var insert = function() {
-        process.nextTick(function() {
+        safe.back(function() {
           collection.insert({a:1});
-          if(running) process.nextTick(insert);
+          if (running) safe.back(insert);
         });
-      }
+      };
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -1277,7 +1277,7 @@ exports.shouldCorrectlyIterateOverCollection = function(configuration, test) {
       });
     });
   });
-}
+};
 
 /**
  * @ignore
@@ -1288,7 +1288,6 @@ exports.shouldCorrectlyErrorOutFindAndModifyOnDuplicateRecord = function(configu
     p_client.createCollection('shouldCorrectlyErrorOutFindAndModifyOnDuplicateRecord', function(err, collection) {
       // Test return old document on change
       collection.insert([{'login':'user1'}, {'login':'user2'}], {w:1}, function(err, docs) {
-		 console
         var id = docs[1]._id;
         // Set an index
         collection.ensureIndex('login', {unique:true, w:1}, function(err, result) {
@@ -1302,7 +1301,7 @@ exports.shouldCorrectlyErrorOutFindAndModifyOnDuplicateRecord = function(configu
       });
     });
   });
-}
+};
 
 /**
  * An example of using find with a very large in parameter
@@ -1395,7 +1394,7 @@ exports.shouldPerformSimpleFindAndModifyOperations = function(configuration, tes
 
                   db.close();
                   test.done();
-              })
+              });
             });
           });
         });
@@ -1403,7 +1402,7 @@ exports.shouldPerformSimpleFindAndModifyOperations = function(configuration, tes
     });
   });
   // DOC_END
-}
+};
 
 /**
  * An example of using findAndRemove
@@ -1446,7 +1445,7 @@ exports.shouldPerformSimpleFindAndModifyOperations = function(configuration, tes
     });
   });
   // DOC_END
-}
+};
 
 /**
  * A simple query using the find method on the collection.
@@ -1482,7 +1481,7 @@ exports.shouldPeformASimpleQuery = function(configuration, test) {
     });
   });
   // DOC_END
-}
+};
 
 /**
  * A simple query showing the explain for a query
@@ -1558,7 +1557,7 @@ exports.shouldPeformASimpleLimitSkipQuery = function(configuration, test) {
     });
   });
   // DOC_END
-}
+};
 
 exports.shouldReturnInstanceofErrorWithBadFieldSelection = function(configuration, test) {
   var db = configuration.newDbInstance({w:0}, {poolSize:1, auto_reconnect:false});
@@ -1577,7 +1576,7 @@ exports.shouldReturnInstanceofErrorWithBadFieldSelection = function(configuratio
       });
     });
   });
-}
+};
 
 /**
  * A simple query using findOne
@@ -1614,7 +1613,7 @@ exports.shouldPeformASimpleLimitSkipFindOneQuery = function(configuration, test)
     });
   });
   // DOC_END
-}
+};
 
 /**
  * A simple query using find and fields
@@ -1654,7 +1653,7 @@ exports.shouldPeformASimpleLimitSkipFindWithFields = function(configuration, tes
       });
     });
   });
-}
+};
 
 /**
  * A simple query using find and fields
@@ -1686,7 +1685,7 @@ exports.shouldPeformASimpleLimitSkipFindWithFields2 = function(configuration, te
       });
     });
   });
-}
+};
 
 /**
  * A simple query with a different batchSize
@@ -1721,7 +1720,7 @@ exports.shouldPerformQueryWithBatchSizeDifferentToStandard = function(configurat
       });
     });
   });
-}
+};
 
 /**
  * A simple query with a different batchSize
@@ -1758,7 +1757,7 @@ exports.shouldCorrectlyPerformNegativeLimit = function(configuration, test) {
     db.collection('shouldCorrectlyPerformNegativeLimit', function(err, collection) {
       var docs = [];
       for(var i = 0; i < 1000; i++) {
-        docs.push({a:1, b:"helloworld helloworld helloworld helloworld helloworld helloworld helloworld helloworld helloworld helloworld"})
+        docs.push({a:1, b:"helloworld helloworld helloworld helloworld helloworld helloworld helloworld helloworld helloworld helloworld"});
       }
 
       // Insert a bunch of documents
@@ -1774,7 +1773,7 @@ exports.shouldCorrectlyPerformNegativeLimit = function(configuration, test) {
       });
     });
   });
-}
+};
 
 /**
  * Should perform an exhaust find query
@@ -1864,7 +1863,7 @@ exports['Each should not hang on iterating over no results'] = function(configur
       });
     });
   });
-}
+};
 
 exports.shouldCorrectlyFindDocumentsByRegExp = function(configuration, test) {
   var client = configuration.db();
@@ -1879,7 +1878,7 @@ exports.shouldCorrectlyFindDocumentsByRegExp = function(configuration, test) {
             collection.findOne({keywords: {$all: [/ser/, /test/, /seg/, /fault/, /nat/]}}, function(err, item) {
               test.equal(6, item.keywords.length);
               if (i === 0) {
-               test.done()
+               test.done();
              }
             });
           };
@@ -1889,7 +1888,7 @@ exports.shouldCorrectlyFindDocumentsByRegExp = function(configuration, test) {
       }
     });
   });
-}
+};
 
 exports.shouldCorrectlyDoFindMinMax = function(configuration, test) {
   var client = configuration.db();
@@ -1901,15 +1900,15 @@ exports.shouldCorrectlyDoFindMinMax = function(configuration, test) {
 
       collection.find({"_id": {$in:['some', 'value', 123]}}, {"_id":1, "max":1}, {}).toArray(function(err, docs) {
         test.equal(null, err);
-        test.equal(10, docs[0].max)
+        test.equal(10, docs[0].max);
 
         collection.find({"_id": {$in:['some', 'value', 123]}}, {fields: {"_id":1, "max":1}}).toArray(function(err, docs) {
           test.equal(null, err);
-          test.equal(10, docs[0].max)
+          test.equal(10, docs[0].max);
 
           test.done();
         });
       });
     });
   });
-}
+};

--- a/test/contrib/insert_tests.js
+++ b/test/contrib/insert_tests.js
@@ -1,6 +1,4 @@
-var Step = require('step')
-  , Buffer = require("safe-buffer").Buffer
-  , Script = require('vm');
+var Step = require('step');
 
 /**
  * Module for parsing an ISO 8601 formatted string into a Date object.
@@ -9,9 +7,10 @@ var Step = require('step')
 var ISODate = function (string) {
   var match;
 
-  if (typeof string.getTime === "function")
-    return string;
-  else if (match = string.match(/^(\d{4})(-(\d{2})(-(\d{2})(T(\d{2}):(\d{2})(:(\d{2})(\.(\d+))?)?(Z|((\+|-)(\d{2}):(\d{2}))))?)?)?$/)) {
+  if (string instanceof Date)
+    return string.valueOf();
+
+  if (match = string.match(/^(\d{4})(-(\d{2})(-(\d{2})(T(\d{2}):(\d{2})(:(\d{2})(\.(\d+))?)?(Z|((\+|-)(\d{2}):(\d{2}))))?)?)?$/)) {
     var date = new Date();
     date.setUTCFullYear(Number(match[1]));
     date.setUTCMonth(Number(match[3]) - 1 || 0);
@@ -36,8 +35,9 @@ var ISODate = function (string) {
     }
 
     return date;
-  } else
-    throw new Error("Invalid ISO 8601 date given.", __filename);
+  }
+
+  throw new Error("Invalid ISO 8601 date given.", __filename);
 };
 
 /**

--- a/test/contrib/mapreduce_tests.js
+++ b/test/contrib/mapreduce_tests.js
@@ -505,8 +505,8 @@ exports.shouldSaveDataToDifferentDbFromMapreduce = function(configuration, test)
 */
 /*exports.shouldCorrectlyReturnNestedKeys = function(configuration, test) {
   var client = configuration.db();
-  var start = new Date().setTime(new Date().getTime() - 10000);
-  var end = new Date().setTime(new Date().getTime() + 10000);
+  var start = new Date().setTime(Date.now() - 10000);
+  var end = new Date().setTime(Date.now() + 10000);
 
   var keys =  {
      "data.lastname": true

--- a/test/import-test.js
+++ b/test/import-test.js
@@ -59,7 +59,7 @@ describe('Import', function () {
 		});
 		it("test find $eq", function (done) {
 			load(sample, function (value, index, callback) {
-				if (Math.random() > 10 / rowcount) return process.nextTick(callback); // ~10 rows
+				if (Math.random() > 10 / rowcount) return safe.back(callback); // ~10 rows
 				coll.find({ id: value.id }, function (err, docs) {
 					if (err) return callback(err);
 					docs.toArray(function (err, rows) {

--- a/test/integrity-test.js
+++ b/test/integrity-test.js
@@ -50,7 +50,8 @@ describe('(FS) Corrupted DB Load', function () {
 				fs.open(coll._filename, 'r+', safe.sure(done, function (fd) {
 					items = items.slice(0,99);
 					length--;
-					fs.truncate(fd, stats.size-100, done);
+					// [DEP0081] DeprecationWarning: Using fs.truncate with a file descriptor is deprecated.
+					(fs.ftruncate || fs.truncate)(fd, stats.size-100, done);
 				}));
 			}));
 		}));

--- a/test/run.js
+++ b/test/run.js
@@ -5,6 +5,7 @@ var path = require('path');
 var Mocha = require('mocha');
 var mocha = new Mocha();
 var safe = require('safe');
+var node_version = Number(process.versions.node.split('.')[0]);
 
 var optimist = require('optimist')
 	.default('reporter','dot')
@@ -30,7 +31,7 @@ if (argv.help) {
 }
 
 var config = {
-	mongo: argv.db == 'mongodb'
+	mongo: argv.db == 'mongodb' && node_version <= 6
 };
 
 var tutils = require('./utils.js');
@@ -89,36 +90,36 @@ var sessions = [
 		console.log('Using defaults');
 		run(cb);
 	}
-]
+];
 
 if (!config.mongo && !argv.default) {
 	sessions.push(function (cb) {
 		console.log('Using global searchInArray');
 		tutils.setConfig({ searchInArray: true , nativeObjectID: false });
 		run(cb);
-	})
+	});
 	sessions.push(function (cb) {
 		console.log('Using BSON ObjectID');
 		tutils.setConfig({ searchInArray: false , nativeObjectID: true });
 		run(cb);
-	})
+	});
 	sessions.push(function (cb) {
 		mocha.grep(/(FS)/);
 		mocha.invert();
 		console.log('InMemory using defaults');
 		tutils.setConfig({ memStore:true });
 		run(cb);
-	})
+	});
 	sessions.push(function (cb) {
 		console.log('InMemory using global searchInArray');
 		tutils.setConfig({ memStore:true, searchInArray: true , nativeObjectID: false });
 		run(cb);
-	})
+	});
 	sessions.push(function (cb) {
 		console.log('InMemory using BSON ObjectID');
 		tutils.setConfig({ memStore:true, searchInArray: false , nativeObjectID: true });
 		run(cb);
-	})
+	});
 }
 
 safe.series(sessions, function (err) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -17,7 +17,7 @@ module.exports.setConfig = function (cfg_) {
 var dbPort = 37017;
 var dbInstance;
 
-var startDb = module.exports.startDb = function (cb) {
+module.exports.startDb = function (cb) {
 	if (!cfg.mongo) return cb();
 	if (dbInstance) return cb(new Error('Database already started'));
 	var dbpath = temp.mkdirSync('mongodb');
@@ -40,7 +40,7 @@ var startDb = module.exports.startDb = function (cb) {
 	ensureUp(3, cb);
 };
 
-var stopDb = module.exports.stopDb = function (cb) {
+module.exports.stopDb = function (cb) {
 	cb = cb || function () {};
 	if (!cfg.mongo) return cb();
 	if (!dbInstance) return cb(new Error('Database is not started'));
@@ -58,11 +58,11 @@ var getDb = module.exports.getDb = function (tag, drop, cb) {
 			if (drop) {
 				db.dropDatabase(safe.sure(cb, function () {
 					var dbs = new Db(tag, new Server('localhost', dbPort),{w:1});
-					dbs.open(cb)
-				}))
+					dbs.open(cb);
+				}));
 			} else
-				cb(null,db)
-		}))
+				cb(null,db);
+		}));
 	}
 	else {
 		if (drop)
@@ -79,15 +79,15 @@ var getDb = module.exports.getDb = function (tag, drop, cb) {
 module.exports.getDbSync = function (tag, db_options, server_options, drop) {
 	if (cfg.mongo) {
 		return new Db(tag, new Server('localhost', dbPort, server_options), db_options);
-	} else {
-		if (drop)
-			delete paths[tag];
-		if (!paths[tag]) {
-			paths[tag] = temp.mkdirSync(tag);
-		}
-		var tingodb = cfg.nativeObjectID ? main_native : (cfg.searchInArray?main_array:main);
-		return new tingodb.Db(paths[tag], {name:tag});
 	}
+
+	if (drop)
+		delete paths[tag];
+	if (!paths[tag]) {
+		paths[tag] = temp.mkdirSync(tag);
+	}
+	var tingodb = cfg.nativeObjectID ? main_native : (cfg.searchInArray?main_array:main);
+	return new tingodb.Db(paths[tag], {name:tag});
 };
 
 module.exports.openEmpty = function (db, cb) {


### PR DESCRIPTION
- Improved compatibility with newest versions of Node.
- Fixed deprecation warnings: [DEP0013] and [DEP0081]
- Temporarily disable MongoDB native driver for testing on Node version greater than v6.
- Added v8 to CI.