### PR TITLE
fix infinite loop for mongoose

### DIFF
--- a/lib/tcoll.js
+++ b/lib/tcoll.js
@@ -423,7 +423,7 @@ tcoll.prototype._wrapTypes = function(obj) {
 			obj[k] = {$wrap:"$oid",v:v.toJSON()};
 		else if (v instanceof self._tdb.Binary)
 			obj[k] = {$wrap: "$bin", v: v.toJSON()};
-		else if (_.isObject(v))
+        else if (_.isObject(v) && !obj.__parentArray)
 			self._wrapTypes(v);
 
 	});
@@ -433,7 +433,7 @@ tcoll.prototype._wrapTypes = function(obj) {
 tcoll.prototype._ensureIds = function(obj) {
 	var self = this;
 	if (_.isFunction(obj.toBSON)) obj = obj.toBSON();
-	
+
 	_.each(obj, function (v,k) {
 		if (k.length >0) {
 			if (k[0]=='$')
@@ -469,7 +469,8 @@ tcoll.prototype._unwrapTypes = function(obj) {
 					var bin = new self._tdb.Binary(new Buffer(v.v, 'base64'));
 					obj[k] = bin;
 				break;
-				default: self._unwrapTypes(v);
+				default:
+                    if (!obj.__parentArray) self._unwrapTypes(v);
 			}
 		}
 	});


### PR DESCRIPTION
Hi , i tried the tungus from root core , but if i use the findOneAndUpdate with Array , i will get error: 
Example : 

`
const gameSchema = Schema({
    name: String
    , developer: String
    , released: Date
    , consoles: {
        type: [{
            name: String,
        }]
    }
});
const Game = mongoose.model('Game', gameSchema);
async function example() {
    try {
        await Game.create({
            name: 'Legend of Zelda: Ocarina of Time',
            developer: 'Nintendo',
            released: new Date('November 21, 1998')
        });
        await Game.findOneAndUpdate({name: 'Legend of Zelda: Ocarina of Time'}, {$set: {consoles: [{name: '1'}, {name: '1'}]}});
    } catch (e) {
        console.warn(e);
    }
}
example();
`
RangeError: Maximum call stack size exceeded
    at Object (native)
    at /Users/anhtran/IdeaProjects/tungus2/node_modules/lodash/lodash.js:1190:19
    at baseKeys (/Users/anhtran/IdeaProjects/tungus2/node_modules/lodash/lodash.js:3496:16)
    at keys (/Users/anhtran/IdeaProjects/tungus2/node_modules/lodash/lodash.js:13298:60)
    at /Users/anhtran/IdeaProjects/tungus2/node_modules/lodash/lodash.js:4912:21
    at baseForOwn (/Users/anhtran/IdeaProjects/tungus2/node_modules/lodash/lodash.js:3002:24)
    at /Users/anhtran/IdeaProjects/tungus2/node_modules/lodash/lodash.js:4886:18
    at Function.forEach (/Users/anhtran/IdeaProjects/tungus2/node_modules/lodash/lodash.js:9334:14)
    at tcoll._wrapTypes (/Users/anhtran/IdeaProjects/tungus2/node_modules/tingodb/lib/tcoll.js:419:4)
    at /Users/anhtran/IdeaProjects/tungus2/node_modules/tingodb/lib/tcoll.js:427:9
    at arrayEach (/Users/anhtran/IdeaProjects/tungus2/node_modules/lodash/lodash.js:508:11)
    at Function.forEach (/Users/anhtran/IdeaProjects/tungus2/node_modules/lodash/lodash.js:9334:14)
    at tcoll._wrapTypes (/Users/anhtran/IdeaProjects/tungus2/node_modules/tingodb/lib/tcoll.js:419:4)
    at /Users/anhtran/IdeaProjects/tungus2/node_modules/tingodb/lib/tcoll.js:427:9
    at /Users/anhtran/IdeaProjects/tungus2/node_modules/lodash/lodash.js:4917:15
    at baseForOwn (/Users/anhtran/IdeaProjects/tungus2/node_modules/lodash/lodash.js:3002:24)

Mongoose send a obj with __parentArray to findAndModify and wrap function come into a infinite loop.
Maybe there are some cleaner method to fix this error. 