### PR TITLE
2 error fixes with tests: "Add missing null check on the projection parameter." and "Fixed $pull never matching objects."

### DIFF
--- a/lib/tcursor.js
+++ b/lib/tcursor.js
@@ -96,8 +96,10 @@ function applyProjectionGet(obj,$set,nobj) {
 			}
 			k = path[i];
 		}
-		if (!_.isUndefined(t[k])) {
-			n[k] = t[k];
+		if (t) {
+			if (!_.isUndefined(t[k])) {
+				n[k] = t[k];
+			}
 		}
 	});
 	return nobj;

--- a/lib/updater.js
+++ b/lib/updater.js
@@ -82,7 +82,7 @@ function applyPull(obj,$op,tdb) {
 		if (_.isArray(t[k])) {
 			var qt = tdb.Finder.matcher({v:v});
 			var matcher = new Function("obj", "return " + (qt.native()) );
-			t[k] = _.reject(t[k], function (obj) { return matcher({v:obj}); });
+			t[k] = _.reject(t[k], function (obj) { return matcher(_.isPlainObject(obj) ? obj : {v:obj}); });
 		} else throw new Error("Cannot apply $pull/$pullAll modifier to non-array");
 	});
 }

--- a/test/misc-test.js
+++ b/test/misc-test.js
@@ -228,4 +228,14 @@ describe('Misc', function () {
 		}));
 	});
 
+	it("$find should not crash on base field being undefined",function (done) {
+		db.collection("findcrash1", {}, safe.sure(done,function (_coll) {
+			_coll.insert({_id:1}, safe.sure(done, function () {
+				_coll.find({_id:1}, {"obj1.obj2":1}).toArray(function (err, result) {
+					assert.equal(err, null);
+					done();
+				})
+			}))
+		}))
+	})
 });

--- a/test/update-test.js
+++ b/test/update-test.js
@@ -325,6 +325,19 @@ describe('Incremental update', function () {
 				}))
 			}))
 		})
+		it("#4 $pull should match objects",function (done) {
+			db.collection("pull", {}, safe.sure(done,function (_coll) {
+				_coll.insert({_id:4,users:[{name:"Bob",age:20},{name:"Bob",age:20},{name:"Alice",age:22}]}, safe.sure(done, function () {
+					_coll.update({_id:4},{$pull:{users: {name: "Bob"}}}, safe.sure(done, function () {
+						_coll.findOne({_id:4},safe.sure(done, function (obj) {
+							assert.deepEqual(obj.users,[{name:"Alice",age:22}]);
+							assert.equal(obj.users.length, 1);
+							done();
+						}))
+					}))
+				}))
+			}))
+		})
 	})
 	describe("$pullAll", function () {
 		it("#1 $pullAll basics",function (done) {


### PR DESCRIPTION
I have found that tingodb will throw an error on the following call when field `test1` does not exist in the matching document:
```
db.collection("test").find({_id: 1234}, {"test1.test2": 1}).toArray(function(err, result) {

});
```
If field `test1` exists but `test2` does not, the function will behave as expected - not provide the missing projection item.

With this change, both cases behave the same way.