### PR TITLE
Fixes querying array index in embedded document with searchInArray turned on

### DIFF
--- a/lib/finder.js
+++ b/lib/finder.js
@@ -728,7 +728,7 @@ var field = function (k) {
 			s+= "v"+i+"="+ps+"\n";
 			s+= "if (!v"+i+") return null;\n";
 			if (path.length!=i) {
-				s+= "if (Array.isArray(v"+i+")) {\n";
+				s+= "if (Array.isArray(v"+i+") && !(Number.isInteger(Number('"+path[i]+"')) && Number('"+path[i]+"') >= 0)) {\n";
 				s+= "for (i"+i+"=0; i"+i+"<v"+i+".length; i"+i+"++) {\n";
 				s+= steep("v"+i+"[i"+i+"]",path,i);
 				s+= "}\n}\nelse\n{\n";

--- a/lib/tcoll.js
+++ b/lib/tcoll.js
@@ -433,7 +433,7 @@ tcoll.prototype._wrapTypes = function(obj) {
 tcoll.prototype._ensureIds = function(obj) {
 	var self = this;
 	if (_.isFunction(obj.toBSON)) obj = obj.toBSON();
-	
+
 	_.each(obj, function (v,k) {
 		if (k.length >0) {
 			if (k[0]=='$')

--- a/test/search-array-test.js
+++ b/test/search-array-test.js
@@ -44,7 +44,15 @@ describe('Search Array', function () {
 					for (j=0; j<10; j++) {
 						arr[j].sub.arr = arr2;
 					}
-					obj = {num:i, pum:i, arr:arr, nags:["tag"+i,"tag"+(i+1)], tags:["tag"+i,"tag"+(i+1)], nested:{tags:["tag"+i,"tag"+(i+1)]}};
+					obj = {
+						num:i,
+						pum:i,
+						arr:arr,
+						nags:["tag"+i,"tag"+(i+1)],
+						tags:["tag"+i,"tag"+(i+1)],
+						nested:{tags:["tag"+i,"tag"+(i+1)]},
+						objectArray:[{tag:"tag"+i}]
+					};
 					coll.insert(obj, cb);
 					i++;
 				},
@@ -297,5 +305,11 @@ describe('Search Array', function () {
 				done();
 			}));
 		});
+    it("find object array {'objectArray.0.tag':'tag1'} (no index)", function (done) {
+      coll.find({'objectArray.0.tag':'tag1'}).toArray(safe.sure(done, function (docs) {
+        assert.equal(docs.length, 1);
+        done();
+      }));
+    });
 	});
 });


### PR DESCRIPTION
Fixes querying array index in embedded document with searchInArray turned on.

Fixes #155 

[MongoDB reference documentation for this feature](https://docs.mongodb.com/manual/tutorial/query-array-of-documents/#use-the-array-index-to-query-for-a-field-in-the-embedded-document)